### PR TITLE
Fix failing exportCsv test from promise rejection

### DIFF
--- a/src/__test__/utils/exportSettings/downloadBlob.test.js
+++ b/src/__test__/utils/exportSettings/downloadBlob.test.js
@@ -20,6 +20,6 @@ describe('downloadBlob', () => {
       fileName
     })
 
-    expect(createObjectURLStub).toHaveBeenCalled()
+    expect(createObjectURLStub).toHaveBeenCalledWith(blob)
   })
 })

--- a/src/__test__/utils/exportSettings/exportCsv.test.js
+++ b/src/__test__/utils/exportSettings/exportCsv.test.js
@@ -6,7 +6,6 @@ import en from '../../../i18n/en'
 import showNotification from '../../../utils/notifications/showNotification'
 
 const fileMock = jest.fn()
-const generateAsyncMock = jest.fn()
 
 jest.mock('../../../utils/notifications/showNotification')
 jest.mock('jszip')
@@ -20,9 +19,11 @@ describe('exportCsv', () => {
     JSZip.mockImplementation(() => (
       {
         file: fileMock,
-        generateAsync: () => Promise.resolve((blob) => generateAsyncMock(blob))
+        generateAsync: () => Promise.resolve('fakeblob')
       }
     ))
+    const createObjectURLStub = jest.fn()
+    window.URL = { createObjectURL: createObjectURLStub }
 
     const exportFileName = 'file'
     const t = (id) => en[id]
@@ -33,6 +34,7 @@ describe('exportCsv', () => {
     })
 
     expect(fileMock).toHaveBeenCalledTimes(2)
+    expect(createObjectURLStub).toHaveBeenCalledWith('fakeblob')
     expect(showNotification).toHaveBeenCalledWith(
       {
         message: 'File can now be downloaded, check your browser!',


### PR DESCRIPTION
In tested logic, `createObjectURL()` gets called but doesn't exist in `JSDOM` mocks. Stub it out for this test, also simplify the mock that feeds the value. Also make the `downloadBlob` which directly deals in values there more exact.

Having a shared or global `createObjectURL()` test mock might be neater, it's replaced in a few other places, and swapping out globals inside of a test can be a little suspect.

To get this to install/build with node 16 I also needed to replace `node-sass` but dependency updates are a bigger thing so leaving alone for now.